### PR TITLE
chore: add note about the status of the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # theme_mode_handler
 
+> This library is considered done - no new features or changes are foreseen.
+> You may not see recent updates to this repository, but the library is totally functional.
+> Please [open an issue](https://github.com/arthurdenner/theme_mode_handler/issues) if you find an issue
+> or think something is missing so we can discuss it.
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 
 [![version][version-badge]][package]

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -52,7 +52,3 @@ linter:
     - use_function_type_syntax_for_parameters
     - use_rethrow_when_possible
     - valid_regexps
-
-analyzer:
-  enable-experiment:
-    - non-nullable


### PR DESCRIPTION
After over one year without updates, it's better to explain why.
Otherwise, people may not use the library thinking it's outdated.